### PR TITLE
Use --hard-dereference flag to avoid hard links in dependency tars

### DIFF
--- a/lib/cf_obs_binary_builder/templates/bundler.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/bundler.spec.erb
@@ -49,7 +49,10 @@ mkdir -p %{buildroot}/var/binary-builder
 cd %{_builddir}
 
 TARBALL=%{otherdir}/%{mod_full_name}.tgz
-tar czvf ${TARBALL} . --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czvf ${TARBALL} --hard-dereference . --owner=0 --group=0
 
 CHECKSUM=`sha256sum ${TARBALL}`
 NEW_TARBALL=%{otherdir}/%{mod_full_name}-%{stack}-${CHECKSUM:0:8}.tgz

--- a/lib/cf_obs_binary_builder/templates/go-dependency.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/go-dependency.spec.erb
@@ -43,7 +43,10 @@ cp ../go/bin/<%= dependency %> bin/
 cp `find -iname LICENSE -maxdepth 1` bin/
 
 TARBALL=%{otherdir}/%{name}-linux-x64.tgz
-tar czf ${TARBALL} bin sources.yml --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czf ${TARBALL} --hard-dereference bin sources.yml --owner=0 --group=0
 
 CHECKSUM=`sha256sum ${TARBALL}`
 NEW_TARBALL=%{otherdir}/%{name}-linux-x64-%{stack}-${CHECKSUM:0:8}.tgz

--- a/lib/cf_obs_binary_builder/templates/go.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/go.spec.erb
@@ -42,7 +42,10 @@ export GOBIN=%{_builddir}/go/bin
 cp %{SOURCE1} ../../
 
 TARBALL=%{otherdir}/%{name}-linux-amd64.tgz
-tar czf ${TARBALL} -C ../../ go sources.yml --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czf ${TARBALL} --hard-dereference -C ../../ go sources.yml --owner=0 --group=0
 
 CHECKSUM=`sha256sum ${TARBALL}`
 NEW_TARBALL=%{otherdir}/%{name}-linux-amd64-%{stack}-${CHECKSUM:0:8}.tgz

--- a/lib/cf_obs_binary_builder/templates/jruby.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/jruby.spec.erb
@@ -50,7 +50,10 @@ mvn -P '!truffle' -Djruby.default.ruby.version=<%= ruby_version %> \
 
 %install
 TARBALL=%{otherdir}/jruby-%{version}.tgz
-tar czvf ${TARBALL} -C %{destdir} bin/ lib/ sources.yml --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czvf ${TARBALL} --hard-dereference -C %{destdir} bin/ lib/ sources.yml --owner=0 --group=0
 
 CHECKSUM=`sha256sum ${TARBALL}`
 NEW_TARBALL=%{otherdir}/jruby-%{version}-%{stack}-${CHECKSUM:0:8}.tgz

--- a/lib/cf_obs_binary_builder/templates/libffi.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/libffi.spec.erb
@@ -47,7 +47,10 @@ make install DESTDIR=%{destdir}
 TARBALL=%{otherdir}/%{name}-linux-x64.tgz
 
 pushd %{dependencydir}
-tar -C %{dependencydir} -czvf ${TARBALL} * --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar -C %{dependencydir} -czvf ${TARBALL} --hard-dereference * --owner=0 --group=0
 popd
 
 CHECKSUM=`sha256sum ${TARBALL}`

--- a/lib/cf_obs_binary_builder/templates/libmemcache.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/libmemcache.spec.erb
@@ -58,7 +58,10 @@ make install DESTDIR=%{destdir}
 TARBALL=%{otherdir}/%{name}-linux-x64.tgz
 
 pushd %{dependencydir}
-tar -C %{dependencydir} -czvf ${TARBALL} * --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar -C %{dependencydir} -czvf ${TARBALL} --hard-dereference * --owner=0 --group=0
 popd
 
 CHECKSUM=`sha256sum ${TARBALL}`

--- a/lib/cf_obs_binary_builder/templates/node.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/node.spec.erb
@@ -47,7 +47,10 @@ cp %{SOURCE1} /tmp/
 make install %{?_smp_mflags} DESTDIR=${DESTDIR} PORTABLE=1
 
 TARBALL=%{otherdir}/%{name}-linux-x64.tgz
-tar czvf ${TARBALL} -C /tmp/%{name} . --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czvf ${TARBALL} --hard-dereference -C /tmp/%{name} . --owner=0 --group=0
 
 CHECKSUM=`sha256sum ${TARBALL}`
 NEW_TARBALL=%{otherdir}/%{name}-linux-x64-%{stack}-${CHECKSUM:0:8}.tgz

--- a/lib/cf_obs_binary_builder/templates/openjdk.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/openjdk.spec.erb
@@ -71,8 +71,12 @@ COMPANY_NAME="SUSE LINUX GmbH" make images
 chmod -R a+r build/linux-x86_64-normal-server-release/images
 #TARBALL1=%{otherdir}/%{full_jdk_name}-%{version}.tar.gz
 TARBALL2=%{otherdir}/%{full_name}-%{version}.tar.gz
-#tar czvf ${TARBALL1} -C build/linux-x86_64-normal-server-release/images/j2sdk-image . --owner=0 --group=0
-tar czvf ${TARBALL2} -C build/linux-x86_64-normal-server-release/images/j2re-image . -C ../j2sdk-image ./lib/tools.jar ./bin/jcmd ./bin/jmap ./bin/jstack ./man/man1/jcmd.1 ./man/man1/jmap.1 ./man/man1/jstack.1 -C ./jre ./lib/amd64/libattach.so --owner=0 --group=0
+
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+#tar czvf ${TARBALL1} --hard-dereference -C build/linux-x86_64-normal-server-release/images/j2sdk-image . --owner=0 --group=0
+tar czvf ${TARBALL2} --hard-dereference -C build/linux-x86_64-normal-server-release/images/j2re-image . -C ../j2sdk-image ./lib/tools.jar ./bin/jcmd ./bin/jmap ./bin/jstack ./man/man1/jcmd.1 ./man/man1/jmap.1 ./man/man1/jstack.1 -C ./jre ./lib/amd64/libattach.so --owner=0 --group=0
 
 #CHECKSUM1=`sha256sum ${TARBALL1}`
 CHECKSUM2=`sha256sum ${TARBALL2}`

--- a/lib/cf_obs_binary_builder/templates/pip-pop.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/pip-pop.spec.erb
@@ -37,7 +37,10 @@ cp %{SOURCE0} %{SOURCE1} %{destdir}/
 TARBALL=%{otherdir}/%{name}.tar.gz
 
 pushd %{destdir}
-tar czf ${TARBALL} * --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czf ${TARBALL} --hard-dereference * --owner=0 --group=0
 popd
 
 CHECKSUM=`sha256sum ${TARBALL}`

--- a/lib/cf_obs_binary_builder/templates/pipenv.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/pipenv.spec.erb
@@ -37,7 +37,10 @@ cp %{_sourcedir}/*.zip  %{_sourcedir}/*.tar.gz %{destdir}/
 TARBALL=%{otherdir}/%{name}-linux-x64.tgz
 
 pushd %{destdir}
-tar czf ${TARBALL} * --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czf ${TARBALL} --hard-dereference * --owner=0 --group=0
 popd
 
 CHECKSUM=`sha256sum ${TARBALL}`

--- a/lib/cf_obs_binary_builder/templates/python.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/python.spec.erb
@@ -62,6 +62,10 @@ TARBALL=%{otherdir}/%{name}-linux-x64.tgz
 
 pushd %{destdir}
 tar czf ${TARBALL} * --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czf ${TARBALL} --hard-dereference * --owner=0 --group=0
 popd
 
 CHECKSUM=`sha256sum ${TARBALL}`

--- a/lib/cf_obs_binary_builder/templates/ruby.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/ruby.spec.erb
@@ -50,7 +50,10 @@ make install DESTDIR=${DESTDIR}
 cp %{SOURCE1} ${APP_PATH}
 
 TARBALL=%{otherdir}/%{name}-linux-x64.tgz
-tar czf ${TARBALL} -C ${APP_PATH} . --owner=0 --group=0
+# The upstream binary-builder is using `cp -r` which has the same effect
+# as the --hard-dereference flag here.
+# (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20)
+tar czf ${TARBALL} --hard-dereference -C ${APP_PATH} . --owner=0 --group=0
 
 CHECKSUM=`sha256sum ${TARBALL}`
 NEW_TARBALL=%{otherdir}/%{name}-linux-x64-%{stack}-${CHECKSUM:0:8}.tgz


### PR DESCRIPTION
The go library used to extract the tarballs doesn't play well with
hardlinks and extracts them as zero-sized files (https://github.com/cloudfoundry/libbuildpack/blob/master/util.go#L198).

The upstream binary builder "breaks" hardlinks probably by coincidence
when copying the files to a different directory (https://github.com/cloudfoundry/binary-builder/blob/master/lib/archive_recipe.rb#L20).

We achieve the same by using the --hard-dereference flag when calling
`tar`.