### PR TITLE
Regenerate packages during sync

### DIFF
--- a/lib/cf_obs_binary_builder/dependencies/base_dependency.rb
+++ b/lib/cf_obs_binary_builder/dependencies/base_dependency.rb
@@ -15,13 +15,8 @@ class CfObsBinaryBuilder::BaseDependency
   def run(verification_data)
     obs_package.create
     obs_package.checkout do
-      write_spec_file
-      prepare_sources
-      validate_checksum(verification_data)
-      write_sources_yaml
-      obs_package.commit
+      generate_package(verification_data)
     end
-    log 'Done!'
   end
 
   def regenerate_spec
@@ -111,5 +106,16 @@ class CfObsBinaryBuilder::BaseDependency
     else
       @file_verified = true
     end
+  end
+
+  private
+
+  def generate_package(verification_data)
+    write_spec_file
+    prepare_sources
+    validate_checksum(verification_data)
+    write_sources_yaml
+    obs_package.commit
+    log 'Done!'
   end
 end

--- a/lib/cf_obs_binary_builder/dependencies/base_dependency.rb
+++ b/lib/cf_obs_binary_builder/dependencies/base_dependency.rb
@@ -19,6 +19,12 @@ class CfObsBinaryBuilder::BaseDependency
     end
   end
 
+  def regenerate(verification_data)
+    obs_package.checkout(reset: true) do
+      generate_package(verification_data)
+    end
+  end
+
   def regenerate_spec
     obs_package.checkout do
       write_spec_file

--- a/lib/cf_obs_binary_builder/obs_package.rb
+++ b/lib/cf_obs_binary_builder/obs_package.rb
@@ -28,12 +28,16 @@ EOF
     end
   end
 
-  def checkout(&block)
+  def checkout(config = {}, &block)
     log 'Checking out the package with osc...'
     Dir.mktmpdir(CfObsBinaryBuilder::TMP_DIR_SUFFIX) do |tmpdir|
       Dir.chdir(tmpdir) do
         `osc checkout #{obs_project}/#{name} -o #{name}`
         Dir.chdir(name) do
+          if config[:reset]
+            log 'Resetting package'
+            FileUtils.rm Dir.glob("*")
+          end
           block.call
         end
       end

--- a/lib/cf_obs_binary_builder/syncer.rb
+++ b/lib/cf_obs_binary_builder/syncer.rb
@@ -12,7 +12,7 @@ class CfObsBinaryBuilder::Syncer
     # Regenerate existing packages to make sure that they got all the new spec
     # changes and extensions
     # Our OBS project is setup that old buildpacks are not rebuild when their
-    # dependencies change
+    # dependencies change (rebuild="local")
     existing.each do |dep|
       checksum = CfObsBinaryBuilder::Checksum.for(dep.dependency, dep.version)
       dep.regenerate(checksum)
@@ -28,8 +28,8 @@ class CfObsBinaryBuilder::Syncer
   end
 
   # Re-generates the spec files for all (existing) dependencies on OBS.
-  # Should be used when something is changed on the dependency templates
-  # but not on the tarball side
+  # Should be only used when it is sure that nothing but the spec has
+  # changed in any of the dependencies
   def regenerate_specs
     existing_deps, _, _ = manifest.dependencies
 

--- a/lib/cf_obs_binary_builder/syncer.rb
+++ b/lib/cf_obs_binary_builder/syncer.rb
@@ -7,7 +7,17 @@ class CfObsBinaryBuilder::Syncer
 
   # Returns a list of unknown dependencies (for which a class should be created)
   def sync
-    _, missing, unknown = manifest.dependencies
+    existing, missing, unknown = manifest.dependencies
+
+    # Regenerate existing packages to make sure that they got all the new spec
+    # changes and extensions
+    # Our OBS project is setup that old buildpacks are not rebuild when their
+    # dependencies change
+    existing.each do |dep|
+      checksum = CfObsBinaryBuilder::Checksum.for(dep.dependency, dep.version)
+      dep.regenerate(checksum)
+    end
+
     missing.each do |dep|
       puts "Creating package for #{dep.package_name}"
       checksum = CfObsBinaryBuilder::Checksum.for(dep.dependency, dep.version)
@@ -18,7 +28,8 @@ class CfObsBinaryBuilder::Syncer
   end
 
   # Re-generates the spec files for all (existing) dependencies on OBS.
-  # Should be used when something is changed on the dependency templates.
+  # Should be used when something is changed on the dependency templates
+  # but not on the tarball side
   def regenerate_specs
     existing_deps, _, _ = manifest.dependencies
 


### PR DESCRIPTION
Adapt `cf-obs-binary-builder sync` to regenerate each dependency package to ensure that for example all new/changed extensions are in every php version which are shipped with the php buildpack manifest.

Our OBS project is setup that old buildpacks are not rebuild when their dependencies change