### PR TITLE
Add support for golang-based buildpacks which are using go modules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 cf_obs_binary_builder-*.gem
+.envrc

--- a/lib/cf_obs_binary_builder/buildpacks/base_buildpack.rb
+++ b/lib/cf_obs_binary_builder/buildpacks/base_buildpack.rb
@@ -44,6 +44,19 @@ class CfObsBinaryBuilder::BaseBuildpack
 
     system("tar -xf v#{version}.tar.gz")
 
+    if File.file?(File.join(tarball_dir,'go.mod'))
+      puts "Buildpack contains go.mod. Generating vendor/ and bundling buildpack-packager"
+
+      # We have to fetch buildpack-packager as
+      # `go mod vendor` filters out non-modules.
+      if !system("cd #{tarball_dir} && wget https://raw.githubusercontent.com/cloudfoundry/libbuildpack/master/packager/buildpack-packager/main.go -O buildpack-packager.go")
+        raise "Could not download buildpack-packager"
+      end
+      if !system("cd #{tarball_dir} && go mod vendor")
+        raise "Failed while running go mod vendor"
+      end
+    end
+
     File.write(File.join(tarball_dir, 'VERSION'), @version)
     FileUtils.mv("manifest.yml", tarball_dir)
 

--- a/lib/cf_obs_binary_builder/buildpacks/base_buildpack.rb
+++ b/lib/cf_obs_binary_builder/buildpacks/base_buildpack.rb
@@ -45,6 +45,21 @@ class CfObsBinaryBuilder::BaseBuildpack
     system("tar -xf v#{version}.tar.gz")
 
     if File.file?(File.join(tarball_dir,'go.mod'))
+
+      # Check if we have go >= 1.11, raise error otherwise
+      go_version = `go version`
+      go_ok=$?.success?
+
+      if !go_ok
+        raise "Can't detect go version"
+      end
+
+      installed_version = go_version.match /go(\d)\.(\d{1,2})\.(\d)/
+
+      if !installed_version || installed_version[1].to_i < 1 || installed_version[2].to_i < 11
+        raise "Found go "+installed_version[1]+"."+installed_version[2]+" . go >=1.11 is required"
+      end
+
       puts "Buildpack contains go.mod. Generating vendor/ and bundling buildpack-packager"
 
       # We have to fetch buildpack-packager as

--- a/lib/cf_obs_binary_builder/templates/buildpack-go-based.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/buildpack-go-based.spec.erb
@@ -41,7 +41,27 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 
 %build
 source ./.envrc
-(cd src/<%= name %>/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager && go install)
+
+if [ -e go.mod ]; then
+
+  # Starting with Go 1.11 modules
+  # installs buildpack-packager from generated vendor
+  go install -mod=vendor buildpack-packager.go
+
+  # With go modules, we are building up the vendor/ folder before landing in obs
+  # both for the buildpack-packager and also for the buildpack itself.
+  VENDOR_GOPATH=%{_builddir}/go
+  export GO111MODULE=off # Disable new behavior, needs network access
+  rm -rf go.mod buildpack-packager.go
+  export GOPATH=$VENDOR_GOPATH:$GOPATH
+  mkdir -p $VENDOR_GOPATH/src/
+  mv vendor/* $VENDOR_GOPATH/src/
+  mkdir -p $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+  cp -rf src/ $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+else
+  (cd src/<%= name %>/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager && go install)
+fi
+
 buildpack-packager build -any-stack
 
 %install
@@ -55,4 +75,3 @@ mv <%= name %>_buildpack-v%{version}.zip %{otherdir}/<%= name %>_buildpack-v%{ve
 %defattr(-,root,root)
 
 %changelog
-


### PR DESCRIPTION
Probably not the cleanest way, but builds fine against latest [nodejs/ruby buildpacks](https://build.opensuse.org/project/show/home:EDiGiacinto:branches:Cloud:Platform:buildpacks):

- Requires Go 1.11 when running it, that is to generate and package the vendor folder to be later used by OBS.
- In the OBS spec, when a buildpack contains a ```go.mod``` file, we reconstruct the GOPATH with the modules fetched previously required while building both ```buildpack-packager``` and the buildpack itself. This is also because ```buildpack-packager``` is not shipped anymore, and the same vendored modules are used for both the buildpack and buildpack-packager.
- Fetches ```buildpack-packager``` main.go during the process - as ```go mod vendor``` filters out non-modules. Ugly, but I saw we fetch already external things for other pieces of buildpack, so I hope it's fine. In theory we could create a separate package for it and avoid to build it during this phase, but still we would need to generate the vendor folder anyway for the buildpack itself.
- Not sure where the go.mod handling should be in the various classes - I've put it in the general BuildPack baseclass as there could be others that could rely on the same building method.

Meanwhile figuring out if there is a less hackish approach that we can take on OBS side