### PR TITLE
Handle go modules based buildpacks with generated vendor from upstream

### DIFF
--- a/lib/cf_obs_binary_builder/templates/buildpack-dotnet-based.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/buildpack-dotnet-based.spec.erb
@@ -48,22 +48,27 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %build
 source ./.envrc
 
-if [ -e go.mod ]; then
+if [ -f go.mod ]; then
 
   # Starting with Go 1.11 modules
-  # installs buildpack-packager from generated vendor
-  go install -mod=vendor buildpack-packager.go
+  # installs buildpack-packager from generated
+  mkdir /tmp/bin
+  export PATH=$PATH:/tmp/bin
+  mv buildpack-packager /tmp/bin/buildpack-packager
+  chmod +x /tmp/bin/buildpack-packager
 
-  # With go modules, we are building up the vendor/ folder before landing in obs
-  # both for the buildpack-packager and also for the buildpack itself.
-  VENDOR_GOPATH=%{_builddir}/go
-  export GO111MODULE=off # Disable new behavior, needs network access
-  rm -rf go.mod buildpack-packager.go
-  export GOPATH=$VENDOR_GOPATH:$GOPATH
-  mkdir -p $VENDOR_GOPATH/src/
-  mv vendor/* $VENDOR_GOPATH/src/
-  mkdir -p $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
-  cp -rf src/ $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+  if [ ! -f "vendor/modules.txt" ]; then
+    # With go modules, we are building up the vendor/ folder before landing in obs
+    # both for the buildpack-packager and also for the buildpack itself.
+    VENDOR_GOPATH=%{_builddir}/go
+    export GO111MODULE=off # Disable new behavior, needs network access
+    rm -rf go.mod buildpack-packager.go
+    export GOPATH=$VENDOR_GOPATH:$GOPATH
+    mkdir -p $VENDOR_GOPATH/src/
+    mv vendor/* $VENDOR_GOPATH/src/
+    mkdir -p $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+    cp -rf src/ $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+  fi
 else
   (cd src/<%= name %>/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager && go install)
 fi

--- a/lib/cf_obs_binary_builder/templates/buildpack-go-based.spec.erb
+++ b/lib/cf_obs_binary_builder/templates/buildpack-go-based.spec.erb
@@ -42,22 +42,26 @@ BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 %build
 source ./.envrc
 
-if [ -e go.mod ]; then
-
+if [ -f go.mod ]; then
   # Starting with Go 1.11 modules
-  # installs buildpack-packager from generated vendor
-  go install -mod=vendor buildpack-packager.go
+  # installs buildpack-packager from generated
+  mkdir /tmp/bin
+  export PATH=$PATH:/tmp/bin
+  mv buildpack-packager /tmp/bin/buildpack-packager
+  chmod +x /tmp/bin/buildpack-packager
 
-  # With go modules, we are building up the vendor/ folder before landing in obs
-  # both for the buildpack-packager and also for the buildpack itself.
-  VENDOR_GOPATH=%{_builddir}/go
-  export GO111MODULE=off # Disable new behavior, needs network access
-  rm -rf go.mod buildpack-packager.go
-  export GOPATH=$VENDOR_GOPATH:$GOPATH
-  mkdir -p $VENDOR_GOPATH/src/
-  mv vendor/* $VENDOR_GOPATH/src/
-  mkdir -p $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
-  cp -rf src/ $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+  if [ ! -f "vendor/modules.txt" ]; then
+    # With go modules, we are building up the vendor/ folder before landing in obs
+    # both for the buildpack-packager and also for the buildpack itself.
+    VENDOR_GOPATH=%{_builddir}/go
+    export GO111MODULE=off # Disable new behavior, needs network access
+    rm -rf go.mod buildpack-packager.go
+    export GOPATH=$VENDOR_GOPATH:$GOPATH
+    mkdir -p $VENDOR_GOPATH/src/
+    mv vendor/* $VENDOR_GOPATH/src/
+    mkdir -p $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+    cp -rf src/ $VENDOR_GOPATH/src/github.com/cloudfoundry/<%= name %>-buildpack
+  fi
 else
   (cd src/<%= name %>/vendor/github.com/cloudfoundry/libbuildpack/packager/buildpack-packager && go install)
 fi


### PR DESCRIPTION
Build buildpack-packager locally and pushes it to obs until we get it
packaged

Signed-off-by: Christian Richter <crichter@suse.com>