### PR TITLE
Revert "Libgdiplus can be verified"

### DIFF
--- a/lib/cf_obs_binary_builder/dependencies/libgdiplus.rb
+++ b/lib/cf_obs_binary_builder/dependencies/libgdiplus.rb
@@ -10,6 +10,18 @@ class CfObsBinaryBuilder::Libgdiplus < CfObsBinaryBuilder::BaseDependency
       @patches = ["libgdiplus_5.6_64bit_comp_issue.patch"]
     end
 
+    def prepare_sources
+      # noop - the sources are fetched from the github repository (no checksum to check against)
+    end
+
+    def write_sources_yaml
+      # noop - the sources are fetched from the github repository (no checksum to check against)
+    end
+
+    def validate_checksum(_checksum)
+      # noop - the sources are fetched from the github repository (no checksum to check against)
+    end
+
     # Keep patches already in the obs package for libgdiplus
     def regenerate(verification_data)
       obs_package.checkout(reset: true) do
@@ -25,6 +37,10 @@ class CfObsBinaryBuilder::Libgdiplus < CfObsBinaryBuilder::BaseDependency
           copy_patches()
           generate_package(verification_data)
         end
+    end
+
+    def validate_checksum(_checksum)
+      # noop - the sources are fetched from the github repository (no checksum to check against)
     end
 
     def copy_patches()


### PR DESCRIPTION
Reverts SUSE/cf-obs-binary-builder#10

For creating a package it's fine, but still we need [the overrides while syncing the manifest](https://concourse.suse.de/teams/main/pipelines/dotnet-dependencies/jobs/add-missing-dotnet-core-obs-dependencies/builds/26).

https://github.com/SUSE/cf-obs-binary-builder/blob/master/lib/cf_obs_binary_builder.rb#L120 :
- Case 1: https://github.com/SUSE/cf-obs-binary-builder/blob/master/lib/cf_obs_binary_builder/syncer.rb#L26
- Case 2: https://github.com/SUSE/cf-obs-binary-builder/blob/master/lib/cf_obs_binary_builder/syncer.rb#L36 -> https://github.com/SUSE/cf-obs-binary-builder/blob/master/lib/cf_obs_binary_builder/dependencies/base_dependency.rb#L119