### PR TITLE
Use base stack for checking the build_status

### DIFF
--- a/lib/cf_obs_binary_builder/buildpacks/base_buildpack.rb
+++ b/lib/cf_obs_binary_builder/buildpacks/base_buildpack.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 class CfObsBinaryBuilder::BaseBuildpack
   include RpmSpecHelpers
 
-  attr_reader :name, :version, :upstream_version, :obs_package, :manifest
+  attr_reader :name, :version, :upstream_version, :obs_package, :obs_project, :manifest
 
   SOURCES_CACHE_DIR = File.expand_path("~/.cf-obs-binary-builder")
 
@@ -13,8 +13,8 @@ class CfObsBinaryBuilder::BaseBuildpack
     @version = "#{@upstream_version}.#{revision}"
 
     package_name = "#{name}-buildpack-#{version}"
-    obs_project = ENV["OBS_BUILDPACK_PROJECT"] || raise("no OBS_BUILDPACK_PROJECT environment variable set")
-    @obs_package = CfObsBinaryBuilder::ObsPackage.new(package_name, obs_project)
+    @obs_project = ENV["OBS_BUILDPACK_PROJECT"] || raise("no OBS_BUILDPACK_PROJECT environment variable set")
+    @obs_package = CfObsBinaryBuilder::ObsPackage.new(package_name, @obs_project)
   end
 
   # Create or update buildpack package on OBS.
@@ -25,9 +25,11 @@ class CfObsBinaryBuilder::BaseBuildpack
     obs_package.create
     obs_package.checkout do
       @manifest = prepare_sources
-      populate_result = @manifest.populate!(stack_mappings, s3_bucket)
-      return populate_result unless populate_result == :succeeded
+      package_statuses = CfObsBinaryBuilder::ObsPackage.project_package_statuses(obs_project)
+      dependency_statuses = @manifest.dependency_statuses(package_statuses)
+      return dependency_statuses unless dependency_statuses == :succeeded
 
+      @manifest.populate!(stack_mappings, s3_bucket)
       @manifest.write("manifest.yml")
       dependencies = []
       stack_mappings.each_key { |stack| dependencies += @manifest.dependencies(stack).first }

--- a/lib/cf_obs_binary_builder/dependencies/dotnet_runtime.rb
+++ b/lib/cf_obs_binary_builder/dependencies/dotnet_runtime.rb
@@ -29,7 +29,7 @@ class RuntimePackage
     true
   end
 
-  def build_status(stacks)
+  def build_status(stack)
     return :succeeded
   end
 

--- a/lib/cf_obs_binary_builder/dependencies/dotnet_sdk.rb
+++ b/lib/cf_obs_binary_builder/dependencies/dotnet_sdk.rb
@@ -30,7 +30,7 @@ class SDKPackage
     true
   end
 
-  def build_status(stacks)
+  def build_status(stack)
     return :succeeded
   end
 

--- a/lib/cf_obs_binary_builder/manifest.rb
+++ b/lib/cf_obs_binary_builder/manifest.rb
@@ -51,6 +51,10 @@ class CfObsBinaryBuilder::Manifest
     @dependencies[base_stack] = [existing_deps, missing_deps, unknown_deps.uniq, third_party_deps]
   end
 
+  def dependency_statuses(package_statuses)
+    # TODO: Write test, implement
+  end
+
   # This method takes a hash of mappings like the one below, and makes sure that the hash
   # of this manifest, includes dependencies for the stacks in the stack_mappings keys.
   # All other stacks in the manifest stays untouched.

--- a/lib/cf_obs_binary_builder/manifest.rb
+++ b/lib/cf_obs_binary_builder/manifest.rb
@@ -77,7 +77,7 @@ class CfObsBinaryBuilder::Manifest
 
       existing.each do |dependency|
         print "Checking #{dependency.package_name}... "
-        build_status = dependency.obs_package.build_status(stack_mappings.keys)
+        build_status = dependency.obs_package.build_status(stack)
 
         case build_status
         when :failed

--- a/lib/cf_obs_binary_builder/obs_package.rb
+++ b/lib/cf_obs_binary_builder/obs_package.rb
@@ -61,12 +61,13 @@ EOF
     system("osc search --package #{name} | grep '#{obs_project} ' > /dev/null")
   end
 
-  # Checks the build status for the stacks we are interested in (and ignores all others).
-  def build_status(stacks)
+  # Checks the build status for the stack we are interested in (and ignores all others).
+  def build_status(stack)
     output, status = Open3.capture2e("osc prjresults #{obs_project} --xml")
     raise "Error getting project results: #{output}" unless status.exitstatus == 0
 
     doc = Nokogiri::XML(output)
+    stacks = [stack]
     repositories = stacks.map{|stack| repository_for_stack(stack) }
     xpath = repositories.map do |repository|
       "//result[@repository='#{repository}']/status[@package='#{name}']"

--- a/spec/cf_obs_binary_builder/obs_package_spec.rb
+++ b/spec/cf_obs_binary_builder/obs_package_spec.rb
@@ -18,7 +18,7 @@ describe CfObsBinaryBuilder::ObsPackage do
       <status package="bundler-1.16.2" code="failed" />
     </result>
     <result  project="Cloud:Platform:buildpacks:dependencies" repository="SLE_12_SP3" arch="x86_64" code="published" state="published">
-      <status package="bundler-1.16.2" code="succeeded" />
+      <status package="bundler-1.16.2" code="failed" />
     </result>
     <result  project="Cloud:Platform:buildpacks:dependencies" repository="IRRELEVANT_STACK" arch="x86_64" code="published" state="published">
       <status package="bundler-1.16.2" code="failed" />
@@ -34,7 +34,7 @@ EOF
       <status package="bundler-1.16.2" code="succeeded" />
     </result>
     <result  project="Cloud:Platform:buildpacks:dependencies" repository="SLE_12_SP3" arch="x86_64" code="published" state="published">
-      <status package="bundler-1.16.2" code="succeeded" />
+      <status package="bundler-1.16.2" code="failed" />
     </result>
     <result  project="Cloud:Platform:buildpacks:dependencies" repository="IRRELEVANT_STACK" arch="x86_64" code="published" state="published">
       <status package="bundler-1.16.2" code="failed" />
@@ -59,21 +59,21 @@ EOF
 EOF
   end
 
-  let(:stacks){ ["sle12","cfsle15fs"] }
+  let(:stack){ "cfsle15fs" }
 
     it "returns :succeeded if all the statuses are 'succeeded'" do
       expect(Open3).to receive(:capture2e).and_return([succeeded_output, double(exitstatus: 0)])
-      expect(subject.build_status(stacks)).to eq(:succeeded)
+      expect(subject.build_status(stack)).to eq(:succeeded)
     end
 
     it "returns :failed if one or more statuses are 'failed'" do
       expect(Open3).to receive(:capture2e).and_return([failed_output, double(exitstatus: 0)])
-      expect(subject.build_status(stacks)).to eq(:failed)
+      expect(subject.build_status(stack)).to eq(:failed)
     end
 
     it "returns :in_process if it is not :succeeded or :failed" do
       expect(Open3).to receive(:capture2e).and_return([in_process_output, double(exitstatus: 0)])
-      expect(subject.build_status(stacks)).to eq(:in_process)
+      expect(subject.build_status(stack)).to eq(:in_process)
     end
   end
 

--- a/spec/cf_obs_binary_builder/obs_package_spec.rb
+++ b/spec/cf_obs_binary_builder/obs_package_spec.rb
@@ -3,6 +3,30 @@ require_relative "../spec_helper"
 describe CfObsBinaryBuilder::ObsPackage do
   subject { described_class.new("bundler-1.16.2", "home:ObsUser") }
 
+  describe ".project_package_statuses" do
+    let(:osc_xml_output) do
+<<XML
+  <resultlist state="9ea3fb39ad70e5513e194eba21fb85d4">
+    <result  project="Cloud:Platform:buildpacks:dependencies" repository="SLE_15" arch="x86_64" code="published" state="published">
+      <status package="bundler-1.16.2" code="succeeded" />
+    </result>
+    <result  project="Cloud:Platform:buildpacks:dependencies" repository="SLE_12_SP3" arch="x86_64" code="published" state="published">
+      <status package="bundler-1.16.2" code="failed" />
+    </result>
+    <result  project="Cloud:Platform:buildpacks:dependencies" repository="IRRELEVANT_STACK" arch="x86_64" code="published" state="published">
+      <status package="bundler-1.16.2" code="failed" />
+    </result>
+  </resultlist>
+XML
+    end
+    it "returns a hash with statuses", focus: true do
+      expect(Open3).to receive(:capture2e).and_return([osc_xml_output, double(exitstatus: 0)])
+
+      expect(described_class.project_package_statuses("Cloud:Platform:buildpacks:dependencies")).to eq(
+        {"cfsle15fs"=>{"bundler-1.16.2"=>"succeeded"}, "sle12"=>{"bundler-1.16.2"=>"failed"}})
+    end
+  end
+
   describe "#obs_project" do
     it "returns the correct value" do
       expect(subject.obs_project).to eq("home:ObsUser")

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -48,6 +48,8 @@ RSpec.configure do |config|
   # triggering implicit auto-inclusion in groups with matching metadata.
   config.shared_context_metadata_behavior = :apply_to_host_groups
 
+  config.filter_run_when_matching :focus
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
otherwise we expect all supported stacks to work which is not always the
case.

This can be optimized. Instead of iterating over our stacks we
should iterate about the upstream ones, `cflinuxfs2` and `cflinuxfs3.`

In this case we would have two runs instead of three and there we can
match multiple repositories (for example for `cflinuxfs2` we can match against `SLE_12_SP3` and `openSUSE_Leap_42.3`).

At the moment we can only check one repo at a time.

At the same time our old stacks are soon gone so the questions is if the changes are worth implementing.
With my fix it only takes a little longer to run then it would be with the refactoring.