### PR TITLE
Move status check inside CfObsBinaryBuilder::ObsPackage

### DIFF
--- a/lib/cf_obs_binary_builder/dependencies/dotnet_runtime.rb
+++ b/lib/cf_obs_binary_builder/dependencies/dotnet_runtime.rb
@@ -25,11 +25,19 @@ class RuntimePackage
     true
   end
 
+  def exists_in_status?(package_statuses)
+    true
+  end
+
   def available?
     true
   end
 
   def build_status(stack)
+    return :succeeded
+  end
+
+  def build_status_in_package_statuses(stack, package_statuses)
     return :succeeded
   end
 

--- a/lib/cf_obs_binary_builder/dependencies/dotnet_sdk.rb
+++ b/lib/cf_obs_binary_builder/dependencies/dotnet_sdk.rb
@@ -26,11 +26,19 @@ class SDKPackage
     true
   end
 
+  def exists_in_status?(package_statuses)
+    true
+  end
+
   def available?
     true
   end
 
   def build_status(stack)
+    return :succeeded
+  end
+
+  def build_status_in_package_statuses(stack, package_statuses)
     return :succeeded
   end
 

--- a/lib/cf_obs_binary_builder/fake_obs_package.rb
+++ b/lib/cf_obs_binary_builder/fake_obs_package.rb
@@ -13,10 +13,18 @@ class FakeObsPackage
     available?
   end
 
-  def build_status(stacks)
+  def exists_in_status?(package_status)
+    available?
+  end
+
+  def build_status(stack)
     return :succeeded if available?
 
     :failed
+  end
+
+  def build_status_in_package_statuses(stack, package_statuses)
+    build_status(stack)
   end
 
   def resolve_dep(stack)

--- a/lib/cf_obs_binary_builder/manifest.rb
+++ b/lib/cf_obs_binary_builder/manifest.rb
@@ -28,7 +28,7 @@ class CfObsBinaryBuilder::Manifest
         dep = dependency_for(dep_hash)
         if dep
           # Check in the list of all the packages in package_statuses
-          if !package_statuses.values.map(&:keys).flatten.include?(dep.package_name)
+          if !dep.obs_package.exists_in_status?(package_statuses)
             if !dep.respond_to?('ignore_missing') or (dep.respond_to?('ignore_missing') and !dep.ignore_missing)
               puts " doesn't exist"
               missing_deps << dep
@@ -69,7 +69,7 @@ class CfObsBinaryBuilder::Manifest
 
       existing.each do |dependency|
         print "#{dependency.package_name}: "
-        build_status = package_statuses.dig(stack,dependency.package_name)&.to_sym
+        build_status = dependency.obs_package.build_status_in_package_statuses(stack, package_statuses)
 
         case build_status
         when :failed
@@ -165,6 +165,7 @@ class CfObsBinaryBuilder::Manifest
   end
 
   def dependencies_for_stack(stack)
+    puts "==== Checking dependencies for stack #{stack} ===="
     hash["dependencies"].select{ |d| d["cf_stacks"].include?(stack) }
   end
 

--- a/lib/cf_obs_binary_builder/obs_package.rb
+++ b/lib/cf_obs_binary_builder/obs_package.rb
@@ -80,6 +80,14 @@ EOF
     system("osc search --package #{name} | grep '#{obs_project} ' > /dev/null")
   end
 
+  def exists_in_status?(package_statuses)
+    package_statuses.values.map(&:keys).flatten.include?("#{name}")
+  end
+
+  def build_status_in_package_statuses(stack, package_statuses)
+    package_statuses.dig(stack,@name)&.to_sym
+  end
+
   # Checks the build status for the stack we are interested in (and ignores all others).
   def build_status(stack)
     output, status = Open3.capture2e("osc prjresults #{obs_project} --xml")


### PR DESCRIPTION
Before we were calling exists?() which was override by other classes to
handle the specific case in other means. Create a specific exists method
when a status is supplied, so it can be re-used by other classes that
are inheriting it.
Extracts into a separate method also build status retrieval. Override for specific dotnet-{sdk,runtime} versions.
Add also print line to separate stack output

TODO: Move this inside a specific class in package_statuses (?)