### PR TITLE
Don't try to validate the checksum when there is not checkum

### DIFF
--- a/lib/cf_obs_binary_builder/dependencies/base_dependency.rb
+++ b/lib/cf_obs_binary_builder/dependencies/base_dependency.rb
@@ -56,7 +56,7 @@ class CfObsBinaryBuilder::BaseDependency
   end
 
   def validate_checksum(verification_data)
-    if verification_data[/^https?:/]
+    if verification_data && verification_data[/^https?:/]
       verify_gpg_signature(source, verification_data)
     else
       verify_checksum(source, verification_data)
@@ -92,6 +92,12 @@ class CfObsBinaryBuilder::BaseDependency
   end
 
   def verify_checksum(source, checksum)
+    # depwatcher couldn't find a checksum. Nothing we can do about it. We just continue.
+    if checksum.nil?
+      @file_verified = true
+      return
+    end
+
     actual_checksum = case checksum.length
     when 32
       md5 = Digest::MD5.file File.basename(source)

--- a/lib/cf_obs_binary_builder/syncer.rb
+++ b/lib/cf_obs_binary_builder/syncer.rb
@@ -32,7 +32,13 @@ class CfObsBinaryBuilder::Syncer
       next if can_generate_checksum
 
       puts "Creating package for #{dep.package_name}"
-      checksum = CfObsBinaryBuilder::Checksum.for(dep.dependency, dep.version)
+      begin
+        checksum = CfObsBinaryBuilder::Checksum.for(dep.dependency, dep.version)
+      rescue JSON::ParserError
+        puts "Depwatcher does not support this dependency anymore and we have to checksum to validate. Will continue without validation."
+        checksum = nil
+      end
+
       dep.run(checksum)
     end
 


### PR DESCRIPTION
If we try a missing dependency that is no longer available in the index
page (of e.g. https://www.ruby-lang.org/en/downloads/), then depwatcher
returns not checksum (actually fails). We can't do nothing else but skip
checksum validation. The sources will be downloaded as usual.